### PR TITLE
Apply my.dmixmvn() to rows inside dmixmvn.wt()

### DIFF
--- a/R/fcn_dlmvnorm.r
+++ b/R/fcn_dlmvnorm.r
@@ -145,7 +145,7 @@ dmixmvn.wt <- function(x, emobj, log = FALSE){
 ###                  Mu (array[nclass, p]), and
 ###                  LTSigma (array[nclass, p * (p + 1) / 2]).
   if(is.matrix(x) || is.data.frame(x)){
-    p <- nrow(x)
+    p <- ncol(x)
   } else if(is.vector(x)){
     p <- length(x)
   } else{
@@ -167,7 +167,7 @@ dmixmvn.wt <- function(x, emobj, log = FALSE){
   }
 
   if(is.matrix(x) || is.data.frame(x)){
-    ret <- apply(x, 2, my.dmixmvn)
+    ret <- apply(x, 1, my.dmixmvn)
   }
   if(is.vector(x)){
     ret <- my.dmixmvn(x) 


### PR DESCRIPTION
While creating #12 I saw this by chance. An example:
``` r
library(EMCluster)
#> Loading required package: MASS
#> Loading required package: Matrix
emobj <- init.EM(da1$da)
dmixmvn(head(da1$da), emobj)
#>            1            2            3            4            5            6 
#> 6.810659e-06 6.958987e-06 6.081588e-06 6.311868e-06 7.346686e-06 6.281716e-06
dmixmvn.wt(head(da1$da), emobj)
#> x y 
#> 0 0
```

<sup>Created on 2022-02-09 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
I think the behavior of `dmixmvn()` is correct and `dmixmvn.wt()` should behave equally.